### PR TITLE
Build on Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
 .*
-inc/
-lib/
+libinsane/
 bin/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Go bindings for [*libinsane*](https://gitlab.gnome.org/World/OpenPaperwork/libin
 
 **lisgo** library is potentially cross-platform, but tested only on Windows yet. 
 
-## How to compile
+## How to compile on Windows
 
 Instructions for compiling 32-bit version.
 
@@ -20,12 +20,48 @@ Instructions for compiling 32-bit version.
         mingw-w64-i686-python3-gobject \
         mingw-w64-i686-vala
     ```
-2. To compile libinsane as a static library, change line #88 in `subprojects\libinsane\src\meson.build` from  
-   `libinsane = library(` to  
-   `libinsane = static_library(`
-3. After building libinsane `make PREFIX=/mingw64` you'll have `libinsane.a` in the build directory. Copy it to `lisgo\lib\libinsane32.a`.
-4. Now issue `..lisgo> make` in MINGW32 shell to compile both library and lisgo32.exe.
+    If you plan on compiling your program as a 64bits executable, you just have to replace all the `i686` by `x86_64` and run it in MINGW64 shell.
 
+2. Download libinsane sources
+    ```
+    wget -c https://gitlab.gnome.org/World/OpenPaperwork/libinsane/-/archive/1.0.10/libinsane-1.0.10.tar.gz -O - | tar -xz
+    mv libinsane-* libinsane
+    ```
+3. To compile libinsane as a static library, change line #88 in `subprojects\libinsane\src\meson.build` from `libinsane = library` to `libinsane = static_library`
+    ```
+    (cd libinsane && sed -i 's/libinsane = library/libinsane = static_library/g' subprojects/libinsane/src/meson.build)
+    ```
+4. Build libinsane
+    ```
+    (cd libinsane && make PREFIX=/mingw64)
+    ```
+5. Set CGO options
+    ```
+    export LIBINSANE_DIR=`cygpath -aw libinsane`
+    export CGO_CFLAGS="-I${LIBINSANE_DIR}/subprojects/libinsane/include"
+    export CGO_LDFLAGS="-L${LIBINSANE_DIR}/build/subprojects/libinsane/src/ -static -linsane -lpthread -lsystre -lintl -ltre -liconv -lregex -lole32 -loleaut32 -luuid"
+6. Build
+    ```
+    go get .
+    go build -o bin/lisgo.exe cmd/lisgo/main.go
+    ```
+
+## How to compile on Ubuntu
+
+1. Install dependencies
+    ```
+    sudo apt get update
+    sudo apt install build-essential libinsane-dev libsane-dev
+    ```
+2. Set CGO options
+    ```
+    export CGO_LDFLAGS="-linsane"
+    ```
+3. Build
+    ```
+    go get .
+    go build -o bin/lisgo cmd/lisgo/main.go
+    ```
 
 ## lisgo.exe command-line utility
 

--- a/lislib.c
+++ b/lislib.c
@@ -17,10 +17,6 @@ void set_log_callbacks() {
 	lis_set_log_callbacks(&g_log_callbacks);
 }
 
-void go_printf(const char* msg) {
-	printf(msg);
-}
-
 void lis_value_print(enum lis_value_type typ, union lis_value *val) {
 	switch (typ)
 	{
@@ -90,7 +86,7 @@ void lis_set_option_proxy(struct lis_item *source, char* opt_name, char *value, 
 	//val = calloc(1, sizeof(union lis_value)); //won't free it as stated in the get_value's doc
 	err->err = lis_set_option(source, opt_name, value);
 	if (err->err != LIS_OK) {
-		sprintf(err->buf, "Error %d in 'lis_set_option_proxy' %s", err, lis_strerror(err->err));
+		sprintf(err->buf, "Error %d in 'lis_set_option_proxy' %s", err->err, lis_strerror(err->err));
 	}
 }
 
@@ -99,7 +95,7 @@ struct lis_scan_session* lis_item_scan_start_proxy(struct lis_item *source, stru
 	//enum lis_error err;
 	err->err = source->scan_start(source, &session);
 	if (err->err != LIS_OK) {
-		sprintf(err->buf, "Error %d in 'lis_item_scan_start_proxy' %s", err, lis_strerror(err->err));
+		sprintf(err->buf, "Error %d in 'lis_item_scan_start_proxy' %s", err->err, lis_strerror(err->err));
 		return NULL;
 	}
 	return session;
@@ -256,10 +252,10 @@ struct lis_item** lis_item_list_sources(struct lis_api *api, char* device_id, st
 struct lis_api *lis_api_get_api(struct error_proxy *err) {
 	struct lis_api *impl = NULL;
 	//disable libinsane normalizer to enable BW & Gray scanning
-	_putenv("LIBINSANE_NORMALIZER_BMP2RAW=0");
-	//_putenv("LIBINSANE_WORKAROUND_CHECK_CAPABILITIES=0");
+	putenv("LIBINSANE_NORMALIZER_BMP2RAW=0");
+	//putenv("LIBINSANE_WORKAROUND_CHECK_CAPABILITIES=0");
 	//disable safe default
-    //_putenv("LIBINSANE_NORMALIZER_SAFE_DEFAULTS=0");
+	//putenv("LIBINSANE_NORMALIZER_SAFE_DEFAULTS=0");
 
 	err->err = lis_safebet(&impl);
 	if (err->err != LIS_OK) {

--- a/lislib.h
+++ b/lislib.h
@@ -44,7 +44,6 @@ int  lis_array_length(void*);
 void logProxy(enum lis_log_level, char*);
 
 //various debug functions
-void go_printf(const char*);
 void set_log_callbacks();
 
 

--- a/lislog.go
+++ b/lislog.go
@@ -42,6 +42,5 @@ func logProxy(lvl C.enum_lis_log_level, msg *C.char) {
 		} else {
 			log.WithField("message", C.GoString(msg)).Debug("libinsane log message")
 		}
-		//C.go_printf(msg)
 	}
 }


### PR DESCRIPTION
Solved build problems on Ubuntu. Edited instructions.

When building on ubuntu, warnings were issued:
```
lislib.c: In function ‘go_printf’:
lislib.c:21:9: warning: format not a string literal and no format arguments [-Wformat-security]
   21 |         printf(msg);
      |         ^~~~~~
lislib.c: In function ‘lis_set_option_proxy’:
lislib.c:93:43: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘struct error_proxy *’ [-Wformat=]
   93 |                 sprintf(err->buf, "Error %d in 'lis_set_option_proxy' %s", err, lis_strerror(err->err));
      |                                          ~^                                ~~~
      |                                           |                                |
      |                                           int                              struct error_proxy *
lislib.c: In function ‘lis_item_scan_start_proxy’:
lislib.c:102:43: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘struct error_proxy *’ [-Wformat=]
  102 |                 sprintf(err->buf, "Error %d in 'lis_item_scan_start_proxy' %s", err, lis_strerror(err->err));
      |                                          ~^                                     ~~~
      |                                           |                                     |
      |                                           int                                   struct error_proxy *
lislib.c: In function ‘lis_api_get_api’:
lislib.c:259:9: warning: implicit declaration of function ‘_putenv’; did you mean ‘putenv’? [-Wimplicit-function-declaration]
  259 |         _putenv("LIBINSANE_NORMALIZER_BMP2RAW=0");
      |         ^~~~~~~
      |         putenv
```