### PR TITLE
Fixed segmentation violation when there are no devices

### DIFF
--- a/lislib.go
+++ b/lislib.go
@@ -73,6 +73,10 @@ func (o *lisgo) ListDevices() ([]*Scanner, error) {
 		return nil, err
 	}
 
+	if cdevs == nil {
+		return nil, nil
+	}
+
 	arrLen := C.lis_array_length(unsafe.Pointer(cdevs))
 
 	//Apply strong magic to get GO slice backed by C null-terminated array
@@ -96,6 +100,10 @@ func (o *lisgo) GetDevice(deviceID string) (*Scanner, error) {
 	if errProxy.ErrNum() != LisOk {
 		err := errors.New(errProxy.Error())
 		return nil, err
+	}
+
+	if cdevs == nil {
+		return nil, nil
 	}
 
 	arrlen := C.lis_array_length(unsafe.Pointer(cdevs))


### PR DESCRIPTION
Solved error when there are no devices.
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x553434]

runtime stack:
runtime.throw({0x5a6027?, 0x7f9920471c80?})
        /snap/go/current/src/runtime/panic.go:1047 +0x5d fp=0x7ffeb8d2d0b8 sp=0x7ffeb8d2d088 pc=0x436add
runtime.sigpanic()
        /snap/go/current/src/runtime/signal_unix.go:825 +0x3e9 fp=0x7ffeb8d2d118 sp=0x7ffeb8d2d0b8 pc=0x44b649

goroutine 1 [syscall]:
runtime.cgocall(0x553190, 0xc00008dd68)
        /snap/go/current/src/runtime/cgocall.go:157 +0x5c fp=0xc00008dd40 sp=0xc00008dd08 pc=0x406a9c
github.com/foenixx/lisgo._Cfunc_lis_array_length(0x0)
        _cgo_gotypes.go:281 +0x48 fp=0xc00008dd68 sp=0xc00008dd40 pc=0x4ef8a8
github.com/foenixx/lisgo.(*lisgo).ListDevices.func2(0x409d05?)
        /root/lisgo/lislib.go:76 +0x3a fp=0xc00008dda0 sp=0xc00008dd68 pc=0x4f0e1a
github.com/foenixx/lisgo.(*lisgo).ListDevices(0xb?)
        /root/lisgo/lislib.go:76 +0xc7 fp=0xc00008de90 sp=0xc00008dda0 pc=0x4f0b47
main.printScanners()
        /root/lisgo/cmd/lisgo/lisgo.go:86 +0x7e fp=0xc00008df38 sp=0xc00008de90 pc=0x55169e
main.main()
        /root/lisgo/cmd/lisgo/lisgo.go:274 +0x17f fp=0xc00008df80 sp=0xc00008df38 pc=0x552adf
runtime.main()
        /snap/go/current/src/runtime/proc.go:250 +0x207 fp=0xc00008dfe0 sp=0xc00008df80 pc=0x439407
runtime.goexit()
        /snap/go/current/src/runtime/asm_amd64.s:1598 +0x1 fp=0xc00008dfe8 sp=0xc00008dfe0 pc=0x465961
```